### PR TITLE
[Datadog Propagator] Faster ID Conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .stack-work/
+dist-newstyle/
 .DS_Store
 *~
 client_session_key.aes

--- a/api/src/OpenTelemetry/Trace/Id.hs
+++ b/api/src/OpenTelemetry/Trace/Id.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  OpenTelemetry.Trace.Id
@@ -61,6 +62,7 @@ import qualified Data.ByteString.Builder as B
 import Data.Hashable (Hashable)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
+import GHC.Generics (Generic)
 
 import Data.ByteString.Short.Internal
 import GHC.Exts
@@ -72,7 +74,7 @@ import Prelude hiding (length)
 
 -- | A valid trace identifier is a 16-byte array with at least one non-zero byte.
 newtype TraceId = TraceId ShortByteString
-  deriving stock (Ord, Eq)
+  deriving stock (Ord, Eq, Generic)
   deriving newtype (Hashable)
 
 -- | A valid span identifier is an 8-byte array with at least one non-zero byte.

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,17 @@
+packages: api
+          sdk
+          otlp
+          exporters/handle
+          exporters/in-memory
+          exporters/otlp
+          propagators/datadog
+          propagators/w3c
+          instrumentation/conduit
+          instrumentation/cloudflare
+          instrumentation/http-client
+          instrumentation/persistent
+          instrumentation/postgresql-simple
+          instrumentation/yesod
+          instrumentation/wai
+          examples/http-server
+          examples/yesod-minimal

--- a/hie.yaml
+++ b/hie.yaml
@@ -78,6 +78,12 @@ cradle:
     - path: "propagators/datadog/src"
       component: "hs-opentelemetry-propagator-datadog:lib"
 
+    - path: "propagators/datadog/test/spec"
+      component: "hs-opentelemetry-propagator-datadog:test:spec"
+
+    - path: "propagators/datadog/benchmark/header-codec/main.hs"
+      component: "hs-opentelemetry-propagator-datadog:bench:header-codec"
+
     - path: "propagators/w3c/src"
       component: "hs-opentelemetry-propagator-w3c:lib"
 

--- a/nix/ghc.nix
+++ b/nix/ghc.nix
@@ -2,5 +2,5 @@
 rec {
   ghc = pkgs.haskell.compiler.${compiler};
   compiler = "ghc${ghcVersion}";
-  ghcVersion = "8107";
+  ghcVersion = "902";
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,22 +5,22 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
-        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
+        "rev": "82e5cd1ad3c387863f0545d7591512e76ab0fc41",
+        "sha256": "090l219mzc0gi33i3psgph6s2pwsc8qy4lyrqjdj4qzkvmaj65a7",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/82e5cd1ad3c387863f0545d7591512e76ab0fc41.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-21.11",
+        "branch": "release-22.05",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe6f909f7d63fc916490e4a487f5bc60f36dabaf",
-        "sha256": "06wjbv1y00hxl00dnqa2lavrbwbid7ms45xijnc79mqnawbw0gz0",
+        "rev": "c8e459ac45ecdfd0042ae79fb1a115811f50021e",
+        "sha256": "0nrvckpi4jj86mpwhwyinmcq0zri9xmrdrf1q3g7ky5c3zlxz0wh",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fe6f909f7d63fc916490e4a487f5bc60f36dabaf.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c8e459ac45ecdfd0042ae79fb1a115811f50021e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/propagators/datadog/.stylish-haskell.yaml
+++ b/propagators/datadog/.stylish-haskell.yaml
@@ -1,0 +1,231 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: group
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account. Default: 80.
+columns: 120
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: lf
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+language_extensions:
+  - DataKinds # for type families?
+  - FlexibleContexts # for `HasCallStack =>'
+  - GeneralizedNewtypeDeriving
+  - NamedFieldPuns

--- a/propagators/datadog/benchmark/header-codec/main.hs
+++ b/propagators/datadog/benchmark/header-codec/main.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+import OpenTelemetry.Propagator.Datadog.Internal
+import OpenTelemetry.Trace.Id                    (TraceId)
+
+import qualified Criterion.Main as C
+
+import           Control.DeepSeq       (NFData)
+import           Data.ByteString       (ByteString)
+import qualified Data.ByteString       as B
+import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString.Short as SB
+import           Data.Word             (Word64)
+
+main :: IO ()
+main =
+  C.defaultMain
+    [ C.bgroup "newTraceIdFromHeader"
+        [ C.bench "new" $ C.nf newTraceIdFromHeader "1"
+        , C.bench "old" $ C.nf (fillLeadingZeros 16 . convertWord64ToBinaryByteString . read) "1"
+        ]
+    , C.bgroup "newHeaderFromTraceId" $
+        let value = SB.pack [0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 10, 11, 12, 13, 14, 15]
+        in
+          [ C.bench "new" $ C.nf newHeaderFromTraceId value
+          , C.bench "old" $ C.nf (BC.pack . show . convertBinaryByteStringToWord64 . SB.fromShort) value
+          ]
+    ]
+
+instance NFData TraceId
+
+convertWord64ToBinaryByteString :: Word64 -> ByteString
+convertWord64ToBinaryByteString =
+  B.pack . toWord8s []
+  where
+    toWord8s acc 0 = acc
+    toWord8s acc n =
+      let (p, q) = n `divMod` (2 ^ (8 :: Int))
+      in toWord8s (fromIntegral q : acc) p
+
+fillLeadingZeros :: Word -> ByteString -> ByteString
+fillLeadingZeros len bs = B.replicate (fromIntegral len - B.length bs) 0 <> bs
+
+convertBinaryByteStringToWord64 :: ByteString -> Word64
+convertBinaryByteStringToWord64 = B.foldl (\acc b -> (2 ^ (8 :: Int)) * acc + fromIntegral b) 0 -- GHC.Prim.indexWord8ArrayAsWord64# とか駆使すると早くなりそう

--- a/propagators/datadog/hs-opentelemetry-propagator-datadog.cabal
+++ b/propagators/datadog/hs-opentelemetry-propagator-datadog.cabal
@@ -5,18 +5,25 @@ version: 0.0.0.0
 author: Kazuki Okamoto (岡本和樹)
 maintainer: kazuki.okamoto@herp.co.jp
 
+common common
+  build-depends: base >= 4 && < 5
+  ghc-options: -Wall
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat
+  default-language: Haskell2010
+
 library
+  import: common
   hs-source-dirs: src
   exposed-modules: OpenTelemetry.Propagator.Datadog
-  build-depends: base == 4.*,
-                 bytestring,
+                   OpenTelemetry.Propagator.Datadog.Internal
+  build-depends: bytestring,
                  hs-opentelemetry-api,
                  hs-opentelemetry-sdk,
-                 http-client,
                  http-types,
+                 primitive,
                  text
-  ghc-options: -Wall
-               -Wcompat
+  ghc-options: -Wcompat
                -Wno-name-shadowing
   if impl(ghc >= 6.4)
     ghc-options: -Wincomplete-record-updates
@@ -45,4 +52,32 @@ library
     ghc-options: -Wmissing-kind-signatures
                  -Woperator-whitespace
                  -Wredundant-bang-patterns
-  default-language: Haskell2010
+
+test-suite spec
+  import: common
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs: test/spec
+  other-modules: OpenTelemetry.Propagator.Datadog.InternalSpec
+  build-depends: hs-opentelemetry-propagator-datadog,
+                 hs-opentelemetry-api,
+                 bytestring,
+                 hspec,
+                 pretty-hex,
+                 QuickCheck
+  ghc-options: -threaded
+               -rtsopts
+               -with-rtsopts=-N
+  build-tool-depends: hspec-discover:hspec-discover
+
+benchmark header-codec
+  import: common
+  type: exitcode-stdio-1.0
+  main-is: main.hs
+  other-modules:
+  hs-source-dirs: benchmark/header-codec
+  build-depends: hs-opentelemetry-propagator-datadog,
+                 hs-opentelemetry-api,
+                 bytestring,
+                 criterion,
+                 deepseq

--- a/propagators/datadog/src/OpenTelemetry/Propagator/Datadog.hs
+++ b/propagators/datadog/src/OpenTelemetry/Propagator/Datadog.hs
@@ -6,30 +6,23 @@ module OpenTelemetry.Propagator.Datadog
   ( datadogTraceContextPropagator
   ) where
 
-import           OpenTelemetry.Common           (TraceFlags (TraceFlags))
-import           OpenTelemetry.Context          (Context, insertSpan,
-                                                 lookupSpan)
-import           OpenTelemetry.Propagator       (Propagator (Propagator, extractor, injector, propagatorNames))
-import           OpenTelemetry.Trace            (SpanContext (SpanContext, isRemote, spanId, traceFlags, traceId, traceState))
-import           OpenTelemetry.Trace.Core       (getSpanContext,
-                                                 wrapSpanContext)
-import           OpenTelemetry.Trace.Id         (SpanId (SpanId),
-                                                 TraceId (TraceId))
-import           OpenTelemetry.Trace.TraceState (TraceState (TraceState))
-import qualified OpenTelemetry.Trace.TraceState as TS
+import           OpenTelemetry.Common                      (TraceFlags (TraceFlags))
+import           OpenTelemetry.Context                     (Context, insertSpan, lookupSpan)
+import           OpenTelemetry.Propagator                  (Propagator (Propagator, extractor, injector, propagatorNames))
+import           OpenTelemetry.Propagator.Datadog.Internal (newHeaderFromSpanId, newHeaderFromTraceId,
+                                                            newSpanIdFromHeader, newTraceIdFromHeader)
+import           OpenTelemetry.Trace                       (SpanContext (SpanContext, isRemote, spanId, traceFlags, traceId, traceState))
+import           OpenTelemetry.Trace.Core                  (getSpanContext, wrapSpanContext)
+import           OpenTelemetry.Trace.Id                    (SpanId (SpanId), TraceId (TraceId))
+import           OpenTelemetry.Trace.TraceState            (TraceState (TraceState))
+import qualified OpenTelemetry.Trace.TraceState            as TS
 
-import           Data.ByteString                (ByteString)
-import qualified Data.ByteString                as B
-import qualified Data.ByteString.Char8          as BC
-import qualified Data.ByteString.Short          as SB
-import           Data.String                    (IsString)
-import qualified Data.Text                      as T
-import           Data.Word                      (Word64)
-import           Network.HTTP.Types             (RequestHeaders,
-                                                 ResponseHeaders)
-import           Text.Read                      (readMaybe)
+import qualified Data.ByteString.Char8 as BC
+import           Data.String           (IsString)
+import qualified Data.Text             as T
+import           Network.HTTP.Types    (RequestHeaders, ResponseHeaders)
 
--- メモ：Open Telemetry の Trace の ID と Datadog の APM の ID の相互変換に関する情報
+-- Reference: bi-directional conversion of IDs of Open Telemetry and ones of Datadog
 -- - https://docs.datadoghq.com/ja/tracing/connect_logs_and_traces/opentelemetry/
 datadogTraceContextPropagator :: (String -> IO ()) -> Propagator Context RequestHeaders ResponseHeaders
 datadogTraceContextPropagator logger =
@@ -38,16 +31,16 @@ datadogTraceContextPropagator logger =
     , extractor = \hs c -> do
         let
           spanContext' = do
-            traceId <- TraceId . SB.toShort . fillLeadingZeros 16 . convertWord64ToBinaryByteString <$> (readMaybe . BC.unpack =<< lookup traceIdKey hs)
-            parentId <- SpanId . SB.toShort . fillLeadingZeros  8 . convertWord64ToBinaryByteString <$> (readMaybe . BC.unpack =<< lookup parentIdKey hs)
+            traceId <- TraceId . newTraceIdFromHeader <$> lookup traceIdKey hs
+            parentId <- SpanId . newSpanIdFromHeader <$> lookup parentIdKey hs
             samplingPriority <- T.pack . BC.unpack <$> lookup samplingPriorityKey hs
             pure $
               SpanContext
                 { traceId
                 , spanId = parentId
                 , isRemote = True
-                , traceFlags = TraceFlags 1 -- 0 だとサンプルされない
-                                            -- 参照：OpenTelemetry.Internal.Trace.Types.isSampled
+                , traceFlags = TraceFlags 1 -- when 0, not sampled
+                                            -- refer: OpenTelemetry.Internal.Trace.Types.isSampled
                 , traceState = TraceState [(TS.Key samplingPriorityKey, TS.Value samplingPriority)]
                 }
         case spanContext' of
@@ -59,8 +52,8 @@ datadogTraceContextPropagator logger =
           Just span' -> do
             SpanContext { traceId, spanId, traceState = TraceState traceState } <- getSpanContext span'
             let
-              traceIdValue = (\(TraceId b) -> BC.pack $ show $ convertBinaryByteStringToWord64 $ SB.fromShort b) traceId
-              parentIdValue = (\(SpanId b) -> BC.pack $ show $ convertBinaryByteStringToWord64 $ SB.fromShort b) spanId
+              traceIdValue = (\(TraceId b) -> newHeaderFromTraceId b) traceId
+              parentIdValue = (\(SpanId b) -> newHeaderFromSpanId b) spanId
             samplingPriority <-
               case lookup (TS.Key samplingPriorityKey) traceState of
                 Nothing -> do
@@ -78,18 +71,3 @@ datadogTraceContextPropagator logger =
     traceIdKey = "x-datadog-trace-id"
     parentIdKey = "x-datadog-parent-id"
     samplingPriorityKey = "x-datadog-sampling-priority"
-
-convertBinaryByteStringToWord64 :: ByteString -> Word64
-convertBinaryByteStringToWord64 = B.foldl (\acc b -> (2 ^ (8 :: Int)) * acc + fromIntegral b) 0 -- GHC.Prim.indexWord8ArrayAsWord64# とか駆使すると早くなりそう
-
-convertWord64ToBinaryByteString :: Word64 -> ByteString
-convertWord64ToBinaryByteString =
-  B.pack . toWord8s []
-  where
-    toWord8s acc 0 = acc
-    toWord8s acc n =
-      let (p, q) = n `divMod` (2 ^ (8 :: Int))
-      in toWord8s (fromIntegral q : acc) p
-
-fillLeadingZeros :: Word -> ByteString -> ByteString
-fillLeadingZeros len bs = B.replicate (fromIntegral len - B.length bs) 0 <> bs

--- a/propagators/datadog/src/OpenTelemetry/Propagator/Datadog/Internal.hs
+++ b/propagators/datadog/src/OpenTelemetry/Propagator/Datadog/Internal.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE Strict             #-}
+
+module OpenTelemetry.Propagator.Datadog.Internal
+  ( newTraceIdFromHeader
+  , newSpanIdFromHeader
+  , newHeaderFromTraceId
+  , newHeaderFromSpanId
+  , showWord64BS
+  , readWord64BS
+  , asciiWord8ToWord8
+  , word8ToAsciiWord8
+  ) where
+
+import           Control.Monad.ST               (ST, runST)
+import           Data.Bits                      (Bits (complement, shift, (.&.)))
+import           Data.ByteString                (ByteString)
+import qualified Data.ByteString.Internal       as BI
+import           Data.ByteString.Short          (ShortByteString)
+import qualified Data.ByteString.Short.Internal as SBI
+import qualified Data.Char                      as C
+import           Data.Primitive.ByteArray       (ByteArray (ByteArray), MutableByteArray, freezeByteArray,
+                                                 indexByteArray, newByteArray, writeByteArray)
+import           Data.Primitive.Ptr             (writeOffPtr)
+import           Data.Word                      (Word64, Word8)
+import           Foreign.ForeignPtr             (withForeignPtr)
+import           Foreign.Storable               (peekElemOff)
+import           System.IO.Unsafe               (unsafeDupablePerformIO)
+
+newTraceIdFromHeader
+  :: ByteString -- ^ ASCII numeric text
+  -> ShortByteString
+newTraceIdFromHeader bs =
+  let
+    len = 16 :: Int
+    !(ByteArray ba) =
+      runST $ do
+        mba <- newByteArray len
+        let w64 = readWord64BS bs
+        writeByteArray mba 0 (0 :: Word64) -- fill zeros to one upper Word64-size area
+        writeByteArrayNbo mba 1 w64 -- offset one Word64-size
+        freezeByteArray mba 0 len
+  in SBI.SBS ba
+
+newSpanIdFromHeader
+  :: ByteString -- ^ ASCII numeric text
+  -> ShortByteString
+newSpanIdFromHeader bs =
+  let
+    len = 8 :: Int
+    !(ByteArray ba) =
+      runST $ do
+        mba <- newByteArray len
+        let w64 = readWord64BS bs
+        writeByteArrayNbo mba 0 w64
+        freezeByteArray mba 0 len
+  in SBI.SBS ba
+
+-- | Write a primitive value to the byte array with network-byte-order (big-endian).
+-- The offset is given in elements of type @a@ rather than in bytes.
+writeByteArrayNbo :: MutableByteArray s -> Int -> Word64 -> ST s ()
+writeByteArrayNbo mba offset value = do
+  writeByteArray mba offset (0 :: Word64)
+  loop 0 value
+  where
+    loop _ 0 = pure ()
+    loop 8 _ = pure ()
+    loop n v = do
+      let
+        -- equivelent:
+        --   (p, q) = v `divMod` (2 ^ (8 :: Int))
+        p = shift v (-8)
+        q = v .&. complement (shift p 8)
+      writeByteArray mba (8 * (offset + 1) - n - 1) (fromIntegral q :: Word8)
+      loop (n + 1) p
+
+readWord64BS :: ByteString -> Word64
+readWord64BS (BI.PS fptr _ len) =
+  unsafeDupablePerformIO $
+    withForeignPtr fptr readWord64Ptr
+  where
+    readWord64Ptr ptr =
+      readWord64PtrOffset 0 0
+      where
+        readWord64PtrOffset offset acc
+          | offset < len = do
+              b <- peekElemOff ptr offset
+              let n = fromIntegral $ asciiWord8ToWord8 b :: Word64
+              readWord64PtrOffset (offset + 1) $ n + acc * 10
+          | otherwise = pure acc
+
+asciiWord8ToWord8 :: Word8 -> Word8
+asciiWord8ToWord8 b = b - fromIntegral (C.ord '0')
+
+newHeaderFromTraceId :: ShortByteString -> ByteString
+newHeaderFromTraceId (SBI.SBS ba) =
+  let w64 = indexByteArrayNbo (ByteArray ba) 1
+  in showWord64BS w64
+
+newHeaderFromSpanId :: ShortByteString -> ByteString
+newHeaderFromSpanId (SBI.SBS ba) =
+  let w64 = indexByteArrayNbo (ByteArray ba) 0
+  in showWord64BS w64
+
+indexByteArrayNbo :: ByteArray -> Int -> Word64
+indexByteArrayNbo ba offset =
+  loop 0 0
+  where
+    loop 8 acc = acc
+    loop n acc = loop (n + 1) $ shift acc 8 + word8ToWord64 (indexByteArray ba $ 8 * offset + n)
+
+showWord64BS :: Word64 -> ByteString
+showWord64BS v =
+  unsafeDupablePerformIO $
+    BI.createUptoN 20 writeWord64Ptr -- 20 = length (show (maxBound :: Word64))
+  where
+    writeWord64Ptr ptr =
+      loop (19 :: Int) v 0 False
+      where
+        loop 0 v offset _ = do
+          writeOffPtr ptr offset (word8ToAsciiWord8 $ fromIntegral v)
+          pure $ offset + 1
+        loop n v offset upper = do
+          let (p, q) = v `divMod` (10 ^ n)
+          if p == 0 && not upper
+            then loop (n - 1) q offset upper
+            else do
+              writeOffPtr ptr offset (word8ToAsciiWord8 $ fromIntegral p)
+              loop (n - 1) q (offset + 1) True
+
+word8ToAsciiWord8 :: Word8 -> Word8
+word8ToAsciiWord8 b = b + fromIntegral (C.ord '0')
+
+word8ToWord64 :: Word8 -> Word64
+word8ToWord64 = fromIntegral

--- a/propagators/datadog/test/spec/OpenTelemetry/Propagator/Datadog/InternalSpec.hs
+++ b/propagators/datadog/test/spec/OpenTelemetry/Propagator/Datadog/InternalSpec.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings  #-}
+
+module OpenTelemetry.Propagator.Datadog.InternalSpec where
+
+import OpenTelemetry.Propagator.Datadog.Internal
+
+import Test.Hspec
+import Test.QuickCheck
+
+import           Data.ByteString       (ByteString)
+import qualified Data.ByteString       as B
+import qualified Data.ByteString.Char8 as BC
+import           Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as SB
+import qualified Data.Char             as C
+import           Data.Word             (Word64)
+import           Hexdump               (simpleHex)
+
+spec :: Spec
+spec = do
+  context "newTraceIdFromHeader" $ do
+    it "is equal to the old implementation" $
+      property $ \x -> do
+        let x' = BC.pack $ show (x :: Word64)
+        HexString (newTraceIdFromHeader x')
+          `shouldBe`
+            HexString (SB.toShort $ fillLeadingZeros 16 $ convertWord64ToBinaryByteString $ read $ BC.unpack x')
+
+  context "newSpanIdFromHeader" $ do
+    it "is equal to the old implementation" $
+      property $ \x -> do
+        let x' = BC.pack $ show (x :: Word64)
+        HexString (newSpanIdFromHeader x')
+          `shouldBe`
+            HexString (SB.toShort $ fillLeadingZeros 8 $ convertWord64ToBinaryByteString $ read $ BC.unpack x')
+
+  context "newHeaderFromTraceId" $ do
+    it "is equal to the old implementation" $
+      property $ \(x1, x2, x3, x4, x5, x6, x7, x8, x9, (x10, x11, x12, x13, x14, x15, x16)) -> do
+        let x' = SB.pack [x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16]
+        newHeaderFromTraceId x'
+          `shouldBe`
+            BC.pack (show $ convertBinaryByteStringToWord64 $ SB.fromShort x')
+
+  context "newHeaderFromSpanId" $ do
+    it "is equal to the old implementation" $
+      property $ \(x1, x2, x3, x4, x5, x6, x7, x8) -> do
+        let x' = SB.pack [x1, x2, x3, x4, x5, x6, x7, x8]
+        newHeaderFromSpanId x'
+          `shouldBe`
+            BC.pack (show $ convertBinaryByteStringToWord64 $ SB.fromShort x')
+
+  context "readWord64BS" $ do
+    it "can get back a value" $
+      property $ \x ->
+        readWord64BS (BC.pack $ show x) `shouldBe` x
+
+  context "showWord64BS" $ do
+    it "can show back a value" $
+      property $ \x ->
+        showWord64BS x `shouldBe` BC.pack (show x)
+
+  context "asciiWord8ToWord8" $ do
+    it "returns 0 for '0'" $
+      asciiWord8ToWord8 (fromIntegral $ C.ord '0') `shouldBe` 0
+
+  context "word8ToAsciiWord8" $ do
+    it "returns '0' for 0" $
+      word8ToAsciiWord8 0 `shouldBe` fromIntegral (C.ord '0')
+
+convertWord64ToBinaryByteString :: Word64 -> ByteString
+convertWord64ToBinaryByteString =
+  B.pack . toWord8s []
+  where
+    toWord8s acc 0 = acc
+    toWord8s acc n =
+      let (p, q) = n `divMod` (2 ^ (8 :: Int))
+      in toWord8s (fromIntegral q : acc) p
+
+fillLeadingZeros :: Word -> ByteString -> ByteString
+fillLeadingZeros len bs = B.replicate (fromIntegral len - B.length bs) 0 <> bs
+
+convertBinaryByteStringToWord64 :: ByteString -> Word64
+convertBinaryByteStringToWord64 = B.foldl (\acc b -> (2 ^ (8 :: Int)) * acc + fromIntegral b) 0 -- GHC.Prim.indexWord8ArrayAsWord64# とか駆使すると早くなりそう
+
+newtype HexString = HexString ShortByteString deriving Eq
+
+instance Show HexString where
+  show (HexString s) = simpleHex $ SB.fromShort s

--- a/propagators/datadog/test/spec/Spec.hs
+++ b/propagators/datadog/test/spec/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/shell.nix
+++ b/shell.nix
@@ -3,16 +3,18 @@ let
   settings = import ./nix/ghc.nix {};
 in
   with pkgs;
-  with settings;
   mkShell {
     buildInputs = [
       niv
 
-      ghc
+      settings.ghc
       stack
+      cabal-install
+      hpack
+      haskell-language-server
+      stylish-haskell
+      hlint
 
-      haskell.packages.${compiler}.implicit-hie
-      haskell.packages.${compiler}.haskell-language-server
-      haskell.packages.${compiler}.hspec-discover
+      zlib
     ];
   }

--- a/stack.yaml
+++ b/stack.yaml
@@ -80,8 +80,8 @@ extra-deps:
 # extra-package-dbs: []
 
 # Control whether we use the GHC we find on the path
-# system-ghc: true
-#
+system-ghc: true
+
 # Require a specific version of stack, using version ranges
 # require-stack-version: -any # Default
 # require-stack-version: ">=2.7"


### PR DESCRIPTION
```
benchmarking newTraceIdFromHeader/new
time                 12.44 ns   (12.03 ns .. 12.95 ns)
                     0.994 R²   (0.991 R² .. 1.000 R²)
mean                 12.19 ns   (12.06 ns .. 12.47 ns)
std dev              607.9 ps   (352.0 ps .. 939.6 ps)
variance introduced by outliers: 74% (severely inflated)

benchmarking newTraceIdFromHeader/old
time                 616.2 ns   (610.6 ns .. 624.3 ns)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 621.2 ns   (615.7 ns .. 628.9 ns)
std dev              21.93 ns   (16.08 ns .. 27.70 ns)
variance introduced by outliers: 51% (severely inflated)

benchmarking newHeaderFromTraceId/new
time                 100.4 ns   (99.75 ns .. 101.3 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 100.4 ns   (99.97 ns .. 101.1 ns)
std dev              1.790 ns   (1.204 ns .. 2.637 ns)
variance introduced by outliers: 23% (moderately inflated)

benchmarking newHeaderFromTraceId/old
time                 175.7 ns   (174.9 ns .. 177.0 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 175.5 ns   (175.1 ns .. 176.2 ns)
std dev              1.902 ns   (1.455 ns .. 2.570 ns)
```